### PR TITLE
chore(build): allow local build without sentry config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,12 +35,3 @@ jobs:
           node-version: 16
       - run: yarn --pure-lockfile
       - run: yarn run build
-        env:
-          SENTRY_URL: ${{secrets.SENTRY_URL}}
-          SENTRY_ORG: ${{secrets.SENTRY_ORG}}
-          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_DSN:  ${{ secrets.SENTRY_DSN }}
-          SENTRY_LOG_LEVEL: ${{ secrets.SENTRY_LOG_LEVEL }}
-          SENTRY_DRY_RUN: ${{ secrets.SENTRY_DRY_RUN }}
-

--- a/next.config.js
+++ b/next.config.js
@@ -6,7 +6,7 @@ const withTM = require('next-transpile-modules')([
 
 const { withSentryConfig } = require('@sentry/nextjs')
 
-const moduleExports = withTM({
+const nextConfig = withTM({
   poweredByHeader: false,
   // Next is kinda buggy and don't want to export into static if this is not set even if its empty and we don't use it
   images: {
@@ -27,4 +27,8 @@ const SentryWebpackPluginOptions = {
   url: process.env.SENTRY_URL,
 }
 
-module.exports = withSentryConfig(moduleExports, SentryWebpackPluginOptions)
+const moduleExports = process.env.SENTRY_AUTH_TOKEN
+  ? withSentryConfig(nextConfig, SentryWebpackPluginOptions)
+  : nextConfig
+
+module.exports = moduleExports


### PR DESCRIPTION
## Summary

## Type

- Refactor

### Summarise concisely:


1. Allow local build work without sentry config
2. Remove env from build ( keep only sentry config on deploy )



