### PR TITLE
fix: fixed copy button

### DIFF
--- a/scaleway-ui.d.ts
+++ b/scaleway-ui.d.ts
@@ -12,6 +12,7 @@ declare module '@scaleway/ui' {
   const Switch: any
   const GlobalStyle: any
   const Separator: any
+  const FlexBox: any
 
   const theme: UITheme
 

--- a/src/components/CopyBoxCommand.tsx
+++ b/src/components/CopyBoxCommand.tsx
@@ -15,7 +15,6 @@ const StyledDiv = styled.div`
 const StyledCopyButton = styled(CopyButton, {
   shouldForwardProp: prop => !['showCopyButton'].includes(prop as string),
 })<{ showCopyButton: boolean }>`
-  display: flex;
   position: absolute;
   right: 16px;
   bottom: 8px;

--- a/src/components/CopyBoxCommand.tsx
+++ b/src/components/CopyBoxCommand.tsx
@@ -15,6 +15,7 @@ const StyledDiv = styled.div`
 const StyledCopyButton = styled(CopyButton, {
   shouldForwardProp: prop => !['showCopyButton'].includes(prop as string),
 })<{ showCopyButton: boolean }>`
+  display: flex;
   position: absolute;
   right: 16px;
   bottom: 8px;

--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -1,27 +1,33 @@
-import { Button, Icon, Tooltip } from '@scaleway/ui'
+import { Button, FlexBox, Icon } from '@scaleway/ui'
 import React from 'react'
 import useClipboard from 'react-use-clipboard'
 
 type CopyButtonProps = {
   text: string
+  className?: string
 }
 
-const CopyButton = ({ text }: CopyButtonProps): JSX.Element => {
+const CopyButton = ({ text, className }: CopyButtonProps): JSX.Element => {
   const [isCopied, setCopied] = useClipboard(text, {
     successDuration: 2000,
   })
 
   return (
-    <Tooltip text={isCopied ? 'Copied!' : 'Copy'}>
+    <FlexBox className={className}>
       <Button
         icon={<Icon name={isCopied ? 'check' : 'copy-content'} size={20} />}
         variant="secondary"
-        ml={2}
         onClick={setCopied}
         size="xsmall"
+        tooltip={isCopied ? 'Copied!' : 'Copy'}
+        display="flex"
       />
-    </Tooltip>
+    </FlexBox>
   )
+}
+
+CopyButton.defaultProps = {
+  className: undefined,
 }
 
 export default CopyButton


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### The following changes where made:

1. Updated props of CopyButton as prop spreading has been removed.

2. Updated tooltip to add flexbox and add classname on it

## Relevant logs and/or screenshots

Page | Before | After
:-   |  :-:   | -:
home | <img width="978" alt="Screenshot 2021-07-23 at 15 26 21" src="https://user-images.githubusercontent.com/15812968/126788565-1e0559d5-45cc-45dc-a70d-31b3d77eb509.png"> | <img width="997" alt="Screenshot 2021-07-23 at 15 25 19" src="https://user-images.githubusercontent.com/15812968/126788610-47870577-aed9-44d3-b5c8-99d83176a8f4.png">




