### PR TITLE
ci: remove hard-coded pnpm version

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -13,8 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.5
       - uses: pnpm/action-setup@v2.2.1
-        with:
-          version: 6.16.0
       - name: Use Node.js
         uses: actions/setup-node@v2.4.1
         with:
@@ -27,8 +25,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.5
       - uses: pnpm/action-setup@v2.2.1
-        with:
-          version: 6.16.0
       - name: Use Node.js
         uses: actions/setup-node@v2.4.1
         with:


### PR DESCRIPTION
Remove the version of `pnpm` in ci, see https://github.com/scaleway/scaleway-ui/pull/1245#discussion_r824848456